### PR TITLE
Fix the LowPowerMode

### DIFF
--- a/ArduCAM/examples/mini/ArduCAM_Mini_OV2640_LowPowerMode/ArduCAM_Mini_OV2640_LowPowerMode.ino
+++ b/ArduCAM/examples/mini/ArduCAM_Mini_OV2640_LowPowerMode/ArduCAM_Mini_OV2640_LowPowerMode.ino
@@ -36,6 +36,10 @@ void setup() {
   
   myCAM.set_mode(MCU2LCD_MODE);
 
+  // make sure the device is not in low power mode
+  myCAM.clear_bit(ARDUCHIP_GPIO, GPIO_PWDN_MASK);
+  delay(100);
+
   //Check if the camera module type is OV2640
   myCAM.rdSensorReg8_8(OV2640_CHIPID_HIGH, &vid);
   myCAM.rdSensorReg8_8(OV2640_CHIPID_LOW, &pid);


### PR DESCRIPTION
When the sketch is idle in loop(), the module's low-power mode will be enabled, which makes the following operations (e.g. after a reboot or re-flashing the sketch) fail, since the module will still be in low-power mode.

Fix this by forcing the module to wake up at the beginning of setup(), and wait 100ms until this seems to have an effect. (This worked 10 out of 10 times when testing with an Arduino Uno on 5V.)