### PR TITLE
Fix to support all SAMD21 proccessors

### DIFF
--- a/ArduCAM/ArduCAM.h
+++ b/ArduCAM/ArduCAM.h
@@ -168,7 +168,7 @@
 	#define regsize uint32_t
 #endif	
 
-#if defined(ARDUINO_SAMD_ZERO)
+#if defined(__SAMD21G18A__)
 	#define Serial SERIAL_PORT_USBVIRTUAL
 
 	#define cbi(reg, bitmask) *reg &= ~bitmask


### PR DESCRIPTION
There is a issue where some ATSAMD21 boards such as the Adafruit ItsyBitsy that don't work with this library due to line 171 defining the section for an Arduino Zero instead of the processor used on the board. Tested with Adafruit Feather M0 and Adafruit ItsyBitsy M0, Feather worked before the change.