### PR TITLE
Added SAMD51 Support

### DIFF
--- a/ArduCAM/ArduCAM.h
+++ b/ArduCAM/ArduCAM.h
@@ -170,7 +170,7 @@
 	#define regsize uint32_t
 #endif	
 
-#if defined(__SAMD21G18A__)
+#if defined(__SAMD51__) || defined(__SAMD21G18A__)
 	#define Serial SERIAL_PORT_USBVIRTUAL
 
 	#define cbi(reg, bitmask) *reg &= ~bitmask


### PR DESCRIPTION
SAMD51 boards such as the Adafruit ItsyBitsy and Adafruit Metro M4 failed to compile previously, this addition allows the same definitions for the SAMD21 to be passed to the library. This has been tested working for SAMD51 and SAMD21 boards.