### PR TITLE
OV5642 Exposure bug fix

### DIFF
--- a/ArduCAM/ArduCAM.cpp
+++ b/ArduCAM/ArduCAM.cpp
@@ -2505,7 +2505,7 @@ void ArduCAM::set_format(byte fmt)
 		switch(level)
 		{
 			case Exposure_17_EV:
-			wrSensorReg16_8(0x3a0f ,0x10);
+			  wrSensorReg16_8(0x3a0f ,0x10);
 				wrSensorReg16_8(0x3a10 ,0x08);
 				wrSensorReg16_8(0x3a1b ,0x10);
 				wrSensorReg16_8(0x3a1e ,0x08);
@@ -2551,6 +2551,8 @@ void ArduCAM::set_format(byte fmt)
 				wrSensorReg16_8(0x3a1b ,0x38);
 				wrSensorReg16_8(0x3a1e ,0x30);
 				wrSensorReg16_8(0x3a1f ,0x10);
+			break;
+			case Exposure03_EV:
 				wrSensorReg16_8(0x3a0f ,0x40);
 				wrSensorReg16_8(0x3a10 ,0x38);
 				wrSensorReg16_8(0x3a11 ,0x71);

--- a/ArduCAM/ArduCAM.h
+++ b/ArduCAM/ArduCAM.h
@@ -431,12 +431,11 @@
 #define Exposure_07_EV                    3
 #define Exposure_03_EV                    4
 #define Exposure_default                  5
-#define Exposure07_EV                     6
-#define Exposure10_EV                     7
-#define Exposure13_EV                     8
-#define Exposure17_EV                     9
-#define Exposure03_EV                     10
-
+#define Exposure03_EV                     6
+#define Exposure07_EV                     7
+#define Exposure10_EV                     8
+#define Exposure13_EV                     9
+#define Exposure17_EV                     10
 
 #define Auto_Sharpness_default              0
 #define Auto_Sharpness1                     1

--- a/ArduCAM/keywords.txt
+++ b/ArduCAM/keywords.txt
@@ -261,6 +261,7 @@ Exposure_10_EV	LITERAL1
 Exposure_07_EV	LITERAL1            
 Exposure_03_EV	LITERAL1            
 Exposure_default	LITERAL1          
+Exposure03_EV	LITERAL1             
 Exposure07_EV	LITERAL1             
 Exposure10_EV	LITERAL1             
 Exposure13_EV	LITERAL1             


### PR DESCRIPTION
I fixed two errors changing the camera’s exposure values: Exposure_default was sending wrong values to the chip (corresponding to +03EV), and Exposure03_EV was missing.