### PR TITLE
adds c++0x flag

### DIFF
--- a/ArduCAM/examples/RaspberryPi/makefile
+++ b/ArduCAM/examples/RaspberryPi/makefile
@@ -1,4 +1,5 @@
 all :  ov2640_capture ov5642_capture ov5640_capture ov2640_4cams_capture ov5640_4cams_capture ov5642_4cams_capture  
+CCFLAGS = -std=c++0x
 VPATH= ../../../ArduCAM
 INCLUDE1 = -I../../../ArduCAM -I./
 INCLUDE2 =-I./ -I../../../ArduCAM
@@ -6,39 +7,39 @@ objects = ArduCAM.o arducam_arch_raspberrypi.o
 
 
 ov2640_capture : $(objects) arducam_ov2640_capture.o 
-	g++ -o ov2640_capture $(objects) arducam_ov2640_capture.o -lwiringPi -Wall	
+	g++ $(CCFLAGS) -o ov2640_capture $(objects) arducam_ov2640_capture.o -lwiringPi -Wall	
 ov5640_capture : $(objects) arducam_ov5640_capture.o 
-	g++ -o ov5640_capture $(objects) arducam_ov5640_capture.o -lwiringPi -Wall
+	g++ $(CCFLAGS) -o ov5640_capture $(objects) arducam_ov5640_capture.o -lwiringPi -Wall
 ov5642_capture : $(objects) arducam_ov5642_capture.o 
-	g++ -o ov5642_capture $(objects) arducam_ov5642_capture.o -lwiringPi -Wall
+	g++ $(CCFLAGS) -o ov5642_capture $(objects) arducam_ov5642_capture.o -lwiringPi -Wall
 	
 ov2640_4cams_capture : $(objects) arducam_ov2640_4cams_capture.o 
-	g++ -o ov2640_4cams_capture $(objects) arducam_ov2640_4cams_capture.o -lwiringPi -Wall
+	g++ $(CCFLAGS) -o ov2640_4cams_capture $(objects) arducam_ov2640_4cams_capture.o -lwiringPi -Wall
 ov5640_4cams_capture : $(objects) arducam_ov5640_4cams_capture.o 
-	g++ -o ov5640_4cams_capture $(objects) arducam_ov5640_4cams_capture.o -lwiringPi -Wall
+	g++ $(CCFLAGS) -o ov5640_4cams_capture $(objects) arducam_ov5640_4cams_capture.o -lwiringPi -Wall
 ov5642_4cams_capture : $(objects) arducam_ov5642_4cams_capture.o 
-	g++ -o ov5642_4cams_capture $(objects) arducam_ov5642_4cams_capture.o -lwiringPi -Wall
+	g++ $(CCFLAGS) -o ov5642_4cams_capture $(objects) arducam_ov5642_4cams_capture.o -lwiringPi -Wall
 
 	
 ArduCAM.o : ArduCAM.cpp 
-	g++ $(INCLUDE1) -c $(VPATH)/ArduCAM.cpp
+	g++ $(CCFLAGS) $(INCLUDE1) -c $(VPATH)/ArduCAM.cpp
 arducam_arch_raspberrypi.o : arducam_arch_raspberrypi.c 
-	g++ $(INCLUDE2) -c arducam_arch_raspberrypi.c 
+	g++ $(CCFLAGS) $(INCLUDE2) -c arducam_arch_raspberrypi.c 
 	
 	
 arducam_ov2640_capture.o : arducam_ov2640_capture.cpp
-	g++ $(INCLUDE2) -c arducam_ov2640_capture.cpp 
+	g++ $(CCFLAGS) $(INCLUDE2) -c arducam_ov2640_capture.cpp 
 arducam_ov5640_capture.o : arducam_ov5640_capture.cpp
-	g++ $(INCLUDE2) -c arducam_ov5640_capture.cpp
+	g++ $(CCFLAGS) $(INCLUDE2) -c arducam_ov5640_capture.cpp
 arducam_ov5642_capture.o : arducam_ov5642_capture.cpp
-	g++ $(INCLUDE2) -c arducam_ov5642_capture.cpp 
+	g++ $(CCFLAGS) $(INCLUDE2) -c arducam_ov5642_capture.cpp 
  	
 arducam_ov2640_4cams_capture.o : arducam_ov2640_4cams_capture.cpp
-	g++ $(INCLUDE2) -c arducam_ov2640_4cams_capture.cpp
+	g++ $(CCFLAGS) $(INCLUDE2) -c arducam_ov2640_4cams_capture.cpp
 arducam_ov5640_4cams_capture.o : arducam_ov5640_4cams_capture.cpp
-	g++ $(INCLUDE2) -c arducam_ov5640_4cams_capture.cpp
+	g++ $(CCFLAGS) $(INCLUDE2) -c arducam_ov5640_4cams_capture.cpp
 arducam_ov5642_4cams_capture.o : arducam_ov5642_4cams_capture.cpp
-	g++ $(INCLUDE2) -c arducam_ov5642_4cams_capture.cpp	
+	g++ $(CCFLAGS) $(INCLUDE2) -c arducam_ov5642_4cams_capture.cpp	
 	
 clean : 
 	rm -f  ov2640_capture ov5640_capture ov5642_capture ov2640_4cams_capture ov5640_4cams_capture ov5642_4cams_capture $(objects) *.o


### PR DESCRIPTION
Hello,

Compiling on the raspberry pi resulted in the warning: extended initializer lists only available with...
This warning is a result of the default compiler not using the latest version of the C++ standard library as explained here: https://stackoverflow.com/questions/21579654/extended-initializer-lists-only-available-with

I fixed the issue by simply adding the flag -std=c++0x to the makefile. This tells the compiler to use the correct version and the code now compiles without warnings.

Hope this helps your team.

All the best,
-