### PR TITLE
Added support for STM32 Arduino core

### DIFF
--- a/ArduCAM/ArduCAM.h
+++ b/ArduCAM/ArduCAM.h
@@ -290,6 +290,22 @@
 #define F(X) (X)
 #endif
 
+#if defined (ARDUINO_ARCH_STM32)
+#define cbi(reg, bitmask) *reg &= ~bitmask
+#define sbi(reg, bitmask) *reg |= bitmask
+
+#define pulse_high(reg, bitmask) sbi(reg, bitmask); cbi(reg, bitmask);
+#define pulse_low(reg, bitmask) cbi(reg, bitmask); sbi(reg, bitmask);
+
+#define cport(port, data) port &= data
+#define sport(port, data) port |= data
+
+#define swap(type, i, j) {type t = i; i = j; j = t;}
+#define fontbyte(x) cfont.font[x]
+#define regtype volatile uint32_t
+#define regsize uint32_t
+#endif
+
 
 /****************************************************/
 /* Sensor related definition 												*/


### PR DESCRIPTION
Hi, I added STM32 support to the Arduino library. It was tested on Nucleo L452RE-P board and OV2640 and it's working fine.