### PR TITLE
Fix command typo in ArduCAM_Mini_5MP_Plus_4CAM_Capture2SD.ino

### DIFF
--- a/ArduCAM/examples/mini/ArduCAM_Mini_5MP_Plus_4CAM_Capture2SD/ArduCAM_Mini_5MP_Plus_4CAM_Capture2SD.ino
+++ b/ArduCAM/examples/mini/ArduCAM_Mini_5MP_Plus_4CAM_Capture2SD/ArduCAM_Mini_5MP_Plus_4CAM_Capture2SD.ino
@@ -55,7 +55,7 @@ Serial.begin(115200);
 Serial.println(F("ArduCAM Start!")); 
 // set the CS output:
 pinMode(CS1, OUTPUT);
-digitalWrite(CS1, HIHG);
+digitalWrite(CS1, HIGH);
 pinMode(CS2, OUTPUT);
 digitalWrite(CS2, HIGH);
 pinMode(CS3, OUTPUT);


### PR DESCRIPTION
Fix typo (`HIHG`) in the `ArduCAM_Mini_5MP_Plus_4CAM_Capture2SD.ino` example file:
Current:
`digitalWrite(CS1, HIHG);` 
to 
`digitalWrite(CS1, HIGH);`