### PR TITLE
Removes redundant macro definitions.

### DIFF
--- a/ArduCAM/ArduCAM.cpp
+++ b/ArduCAM/ArduCAM.cpp
@@ -112,7 +112,6 @@
 	#include <SPI.h>
 	#include "HardwareSerial.h"
 	#if defined(__SAM3X8E__)
-	#define Wire Wire1
 	#endif
 #endif
 


### PR DESCRIPTION
Remove redundant macro definitions to avoid DUE being unable to use Wire0.