### PR TITLE
Fixup ov5642 example to build on Raspberry Pi

### DIFF
--- a/ArduCAM/examples/RaspberryPi/arducam_arch_raspberrypi.c
+++ b/ArduCAM/examples/RaspberryPi/arducam_arch_raspberrypi.c
@@ -18,6 +18,9 @@
 #include <time.h>
 #include "arducam_arch_raspberrypi.h"
 
+extern "C" {
+#include <i2c/smbus.h>
+}
 
 #define	SPI_ARDUCAM_SPEED	1000000
 #define	SPI_ARDUCAM		      0

--- a/ArduCAM/examples/RaspberryPi/arducam_ov5642_capture.cpp
+++ b/ArduCAM/examples/RaspberryPi/arducam_ov5642_capture.cpp
@@ -17,7 +17,7 @@
 #define OV5642_CHIPID_LOW 0x300b
 #define OV5642_MAX_FIFO_SIZE		0x7FFFFF		//8MByte
 #define BUF_SIZE 4096
-#define CAM1_CS 5
+#define CAM1_CS 5     // Currently this is ignored and SPI_CE0_N (GPIO 08) must be used.
 
 #define VSYNC_LEVEL_MASK   		0x02  //0 = High active , 		1 = Low active
 uint8_t buf[BUF_SIZE];

--- a/ArduCAM/examples/RaspberryPi/makefile
+++ b/ArduCAM/examples/RaspberryPi/makefile
@@ -7,18 +7,18 @@ objects = ArduCAM.o arducam_arch_raspberrypi.o
 
 
 ov2640_capture : $(objects) arducam_ov2640_capture.o 
-	g++ $(CCFLAGS) -o ov2640_capture $(objects) arducam_ov2640_capture.o -lwiringPi -Wall	
+	g++ $(CCFLAGS) -o ov2640_capture $(objects) arducam_ov2640_capture.o -lwiringPi -li2c -Wall	
 ov5640_capture : $(objects) arducam_ov5640_capture.o 
-	g++ $(CCFLAGS) -o ov5640_capture $(objects) arducam_ov5640_capture.o -lwiringPi -Wall
+	g++ $(CCFLAGS) -o ov5640_capture $(objects) arducam_ov5640_capture.o -lwiringPi -li2c -Wall
 ov5642_capture : $(objects) arducam_ov5642_capture.o 
-	g++ $(CCFLAGS) -o ov5642_capture $(objects) arducam_ov5642_capture.o -lwiringPi -Wall
+	g++ $(CCFLAGS) -o ov5642_capture $(objects) arducam_ov5642_capture.o -lwiringPi -li2c -Wall
 	
 ov2640_4cams_capture : $(objects) arducam_ov2640_4cams_capture.o 
-	g++ $(CCFLAGS) -o ov2640_4cams_capture $(objects) arducam_ov2640_4cams_capture.o -lwiringPi -Wall
+	g++ $(CCFLAGS) -o ov2640_4cams_capture $(objects) arducam_ov2640_4cams_capture.o -lwiringPi -li2c -Wall
 ov5640_4cams_capture : $(objects) arducam_ov5640_4cams_capture.o 
-	g++ $(CCFLAGS) -o ov5640_4cams_capture $(objects) arducam_ov5640_4cams_capture.o -lwiringPi -Wall
+	g++ $(CCFLAGS) -o ov5640_4cams_capture $(objects) arducam_ov5640_4cams_capture.o -lwiringPi -li2c -Wall
 ov5642_4cams_capture : $(objects) arducam_ov5642_4cams_capture.o 
-	g++ $(CCFLAGS) -o ov5642_4cams_capture $(objects) arducam_ov5642_4cams_capture.o -lwiringPi -Wall
+	g++ $(CCFLAGS) -o ov5642_4cams_capture $(objects) arducam_ov5642_4cams_capture.o -lwiringPi -li2c -Wall
 
 	
 ArduCAM.o : ArduCAM.cpp 


### PR DESCRIPTION
This allows the Raspberry Pi examples to build on a Raspberry Pi W 2 with `Raspbian GNU/Linux 11 (bullseye)`.