### PR TITLE
Add support for Uno R4 Minima + WIFI

### DIFF
--- a/ArduCAM/ArduCAM.h
+++ b/ArduCAM/ArduCAM.h
@@ -306,6 +306,21 @@
 #define regsize uint32_t
 #endif
 
+#if defined (ARDUINO_UNOR4_MINIMA) || defined (ARDUINO_UNOR4_WIFI)
+#define cbi(reg, bitmask) *reg &= ~bitmask
+#define sbi(reg, bitmask) *reg |= bitmask
+
+#define pulse_high(reg, bitmask) sbi(reg, bitmask); cbi(reg, bitmask);
+#define pulse_low(reg, bitmask) cbi(reg, bitmask); sbi(reg, bitmask);
+
+#define cport(port, data) port &= data
+#define sport(port, data) port |= data
+
+#define fontbyte(x) cfont.font[x]
+#define regtype volatile uint16_t
+#define regsize uint16_t
+#endif
+
 
 /****************************************************/
 /* Sensor related definition 												*/

--- a/ArduCAM/ArduCAM.h
+++ b/ArduCAM/ArduCAM.h
@@ -96,6 +96,7 @@
 	2017/11/27  V4.1.2  by Max      Add support for Feather M0
 	2018/10/15  V4.1.2  by Lee      Add support for NRF52
 	2018/10/15  V4.1.2  by Lee      Add support for TEENSYDUINO
+        2024/09/28  V4.1.3  by Keeeal   Add support for Uno R4 Minima + WIFI
 --------------------------------------*/
 
 #ifndef ArduCAM_H


### PR DESCRIPTION
Adds support for Uno R4 Minima + WIFI

Closes #590 

## Compiler options

It looks like the compiler options used to specify the R4 Minima and R4 WIFI are [ARDUINO_UNOR4_MINIMA](https://github.com/arduino/ArduinoCore-renesas/blob/7b8aba7282762ce78cad10f6080e08db30f4d3aa/boards.txt#L69C41-L69C61) and [ARDUINO_UNOR4_WIFI](https://github.com/arduino/ArduinoCore-renesas/blob/7b8aba7282762ce78cad10f6080e08db30f4d3aa/boards.txt#L122C73-L122C91) respectively.

## Explanation of each definition

### CBI and SBI

Clear Bit In and Set Bit In macros.

```
#define cbi(reg, bitmask) *reg &= ~bitmask
#define sbi(reg, bitmask) *reg |= bitmask
```

I am not 100% confident these are the correct implementations over `digitalWrite(bitmask, LOW)`.

### pulse_high and pulse_low

These are the same for all board variants given the CBI+SBI are correct.

```
#define pulse_high(reg, bitmask) sbi(reg, bitmask); cbi(reg, bitmask);
#define pulse_low(reg, bitmask) cbi(reg, bitmask); sbi(reg, bitmask);
```

### Clear Port and Set Port

Also the same as for all other board variants.

```
#define cport(port, data) port &= data
#define sport(port, data) port |= data
```

### Swap and fontbyte

The `swap` macro conflicts with the definition in `tuple.h`, which is included in the Uno R4's implementation of `SPI.h`. However, `swap` doesn't seem to be used anywhere else in this repo, so I did not define it here.

```
#define fontbyte(x) cfont.font[x]
```

`fontbyte` is also not used in this repo but it isn't causing any problems so I left it alone.

### Register types

**These seem to be the only definitions that are actually used anywhere in this repo**

I initially thought that since the Renesas RA4M1 is a 32 bit CPU, the registers would be `uint32_t`, but that throws an error at compile time suggesting they are `uint16_t` registers. Using `uint16_t` compiles without issue.

```
#define regtype volatile uint16_t
#define regsize uint16_t
```

### This is currently untested!

My camera modules haven't arrived yet. This change was sufficient to compile the examples but I do not know whether it works with the camera yet!